### PR TITLE
Fix animations with an odd column count

### DIFF
--- a/decoder.cpp
+++ b/decoder.cpp
@@ -247,16 +247,14 @@ void Decoder::readDeltaChunk(Frame& frame)
         if (word & 0x4000) {   // Has bit 14 (0x4000)
           y += -word;          // Skip lines
         }
-        // Only last pixel has changed
+        // The last pixel of the current line has changed
+        // This code exists for animations with an odd column count. The changes at the other positions follow.
         else {
           assert(y >= 0 && y < m_height);
           if (y >= 0 && y < m_height) {
             uint8_t* it = frame.pixels + y*frame.rowstride + m_width - 1;
             *it = (word & 0xff);
           }
-          ++y;
-          if (nlines-- == 0)
-            return;             // We are done
         }
       }
       else {


### PR DESCRIPTION
The "last column changed" sequence is not supposed to increase row id, as it exists to support animations with odd column counts (the chunk type is encoded using 16-bit words). The commit fixes loading of animations that are like this.


<!-- Please read the contribution guidelines before submitting a pull request. -->
<!-- By submitting this pull request, you agree that your contributions are
     licensed under the Flic license, and agree to future changes to the
     licensing. -->
<!-- If you're a first-time contributor, please acknowledge it by
     leaving the statement below. -->

I agree that my contributions are licensed under the Flic license, and agree to future changes to the licensing.
